### PR TITLE
Missing & using the RAW encoder

### DIFF
--- a/src/main/java/com/ning/http/util/UriEncoder.java
+++ b/src/main/java/com/ning/http/util/UriEncoder.java
@@ -92,6 +92,7 @@ public enum UriEncoder {
             // concatenate raw query + raw query params
             StringBuilder sb = StringUtils.stringBuilder();
             sb.append(query);
+            sb.append('&');
             appendRawQueryParams(sb, queryParams);
             sb.setLength(sb.length() - 1);
             return sb.toString();


### PR DESCRIPTION
The RAW encoder behaves differently than the FIXED in that it isn't prefixing with the first added query parameter with a `&` .